### PR TITLE
Fix memberlist resetting the search state after navigation

### DIFF
--- a/__tests__/actions/__snapshots__/members.spec.js.snap
+++ b/__tests__/actions/__snapshots__/members.spec.js.snap
@@ -65,3 +65,12 @@ Object {
   "type": "MEMBERS_MEMBERS_SUCCESS",
 }
 `;
+
+exports[`member actions should create an action to open the member list 1`] = `
+Object {
+  "payload": Object {
+    "keywords": "",
+  },
+  "type": "MEMBERS_MEMBERS",
+}
+`;

--- a/__tests__/actions/members.spec.js
+++ b/__tests__/actions/members.spec.js
@@ -2,12 +2,17 @@ import * as actions from '../../app/actions/members';
 
 describe('member actions', () => {
   it('should expose the member actions', () => {
+    expect(actions.OPEN).toEqual('MEMBERS_OPEN');
     expect(actions.MEMBERS).toEqual('MEMBERS_MEMBERS');
     expect(actions.FETCHING).toEqual('MEMBERS_FETCHING');
     expect(actions.MEMBERS_SUCCESS).toEqual('MEMBERS_MEMBERS_SUCCESS');
     expect(actions.FAILURE).toEqual('MEMBERS_FAILURE');
     expect(actions.MORE).toEqual('MEMBERS_MORE');
     expect(actions.MORE_SUCCESS).toEqual('MEMBERS_MORE_SUCCESS');
+  });
+
+  it('should create an action to open the member list', () => {
+    expect(actions.members()).toMatchSnapshot();
   });
 
   it('should create an action to notify the member list should be fetched unfiltered', () => {

--- a/__tests__/sagas/navigation.spec.js
+++ b/__tests__/sagas/navigation.spec.js
@@ -73,7 +73,7 @@ describe('navigation saga', () => {
       }));
 
     it('should open the members screen', () => expectSaga(navigationSaga)
-      .dispatch(membersActions.members())
+      .dispatch(membersActions.open())
       .silentRun()
       .then(() => {
         expect(NavigationService.navigate).toBeCalledWith('MemberList');

--- a/app/actions/members.js
+++ b/app/actions/members.js
@@ -1,9 +1,16 @@
+export const OPEN = 'MEMBERS_OPEN';
 export const MEMBERS = 'MEMBERS_MEMBERS';
 export const FETCHING = 'MEMBERS_FETCHING';
 export const MEMBERS_SUCCESS = 'MEMBERS_MEMBERS_SUCCESS';
 export const FAILURE = 'MEMBERS_FAILURE';
 export const MORE = 'MEMBERS_MORE';
 export const MORE_SUCCESS = 'MEMBERS_MORE_SUCCESS';
+
+export function open() {
+  return {
+    type: OPEN,
+  };
+}
 
 export function members(keywords = '') {
   return {

--- a/app/sagas/navigation.js
+++ b/app/sagas/navigation.js
@@ -36,7 +36,7 @@ export default function* () {
   yield takeEvery(welcomeActions.OPEN, navigate, 'Welcome');
   yield takeEvery(settingsActions.OPEN, navigate, 'Settings');
   yield takeEvery(calendarActions.OPEN, navigate, 'Calendar');
-  yield takeEvery(membersActions.MEMBERS, navigate, 'MemberList');
+  yield takeEvery(membersActions.OPEN, navigate, 'MemberList');
   yield takeEvery(eventActions.OPEN, navigate, 'Event');
   yield takeEvery(eventActions.ADMIN, navigate, 'EventAdmin');
   yield takeEvery(profileActions.PROFILE, navigate, 'Profile');

--- a/app/ui/components/searchHeader/SearchHeader.js
+++ b/app/ui/components/searchHeader/SearchHeader.js
@@ -4,6 +4,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import StatusBar from '@react-native-community/status-bar';
+import { NavigationEvents } from 'react-navigation';
 
 import styles from './style/SearchHeader';
 import Colors from '../../style/Colors';
@@ -19,8 +20,10 @@ class SearchHeader extends Component {
       scaleValue: new Animated.Value(props.searchKey ? 1 : 0.01),
       searchKey: props.searchKey,
     };
+  }
 
-    BackHandler.addEventListener('hardwareBackPress', () => {
+  addBackHandler = () => {
+    this.backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
       const { isSearching } = this.state;
       if (isSearching) {
         this.updateSearch(false);
@@ -28,7 +31,11 @@ class SearchHeader extends Component {
       }
       return false;
     });
-  }
+  };
+
+  removeBackHandler = () => {
+    this.backHandler.remove();
+  };
 
   getLeftIcon = () => {
     const { leftIcon, leftIconAction } = this.props;
@@ -128,6 +135,10 @@ class SearchHeader extends Component {
     const { isAnimating, isSearching, scaleValue } = this.state;
     return (
       <View>
+        <NavigationEvents
+          onWillFocus={this.addBackHandler}
+          onDidBlur={this.removeBackHandler}
+        />
         <StatusBar
           backgroundColor={Colors.semiTransparent}
           translucent

--- a/app/ui/components/sidebar/SidebarConnector.js
+++ b/app/ui/components/sidebar/SidebarConnector.js
@@ -16,7 +16,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   loadProfile: () => dispatch(profileActions.profile()),
   openCalendar: () => dispatch(calendarActions.open()),
-  openMemberList: () => dispatch(membersActions.members()),
+  openMemberList: () => dispatch(membersActions.open()),
   openWelcome: () => dispatch(welcomeActions.open()),
   openSettings: () => dispatch(settingsActions.open()),
   openPhotos: () => dispatch(photosActions.openAlbums()),


### PR DESCRIPTION
### Summary

Fixes the bug where the memberlist resets the search state after visiting a user's profile. Hooks into the `react-navigation` event listener, to ensure that the back button listener in the search header does not take precedence over the regular back button behaviour.

### How to test
Steps to test the changes you made:
1. Go to the member list
2. Search for someone and/or scroll down the list
3. Visit a user profile
4. Press the back button
5. Notice that the member list has not reset, and is still in the same state and offset
