### PR TITLE
Add search bar for calendar events

### DIFF
--- a/__tests__/actions/__snapshots__/calendar.spec.js.snap
+++ b/__tests__/actions/__snapshots__/calendar.spec.js.snap
@@ -14,6 +14,7 @@ Object {
         "pk": 1,
       },
     ],
+    "keywords": "keywords",
   },
   "type": "CALENDAR_SUCCESS",
 }
@@ -33,6 +34,18 @@ Object {
 
 exports[`calendar actions should create an action to refresh the calendar 1`] = `
 Object {
-  "type": "CALENDAR_REFRESH",
+  "payload": Object {
+    "keywords": "",
+  },
+  "type": "CALENDAR_EVENTS",
+}
+`;
+
+exports[`calendar actions should create an action with keywords to refresh the calendar 1`] = `
+Object {
+  "payload": Object {
+    "keywords": "keywords",
+  },
+  "type": "CALENDAR_EVENTS",
 }
 `;

--- a/__tests__/actions/calendar.spec.js
+++ b/__tests__/actions/calendar.spec.js
@@ -3,7 +3,7 @@ import * as actions from '../../app/actions/calendar';
 describe('calendar actions', () => {
   it('should expose the calendar actions', () => {
     expect(actions.OPEN).toEqual('CALENDAR_OPEN');
-    expect(actions.REFRESH).toEqual('CALENDAR_REFRESH');
+    expect(actions.EVENTS).toEqual('CALENDAR_EVENTS');
     expect(actions.SUCCESS).toEqual('CALENDAR_SUCCESS');
     expect(actions.FAILURE).toEqual('CALENDAR_FAILURE');
     expect(actions.FETCHING).toEqual('CALENDAR_FETCHING');
@@ -18,7 +18,11 @@ describe('calendar actions', () => {
   });
 
   it('should create an action to refresh the calendar', () => {
-    expect(actions.refresh()).toMatchSnapshot();
+    expect(actions.events()).toMatchSnapshot();
+  });
+
+  it('should create an action with keywords to refresh the calendar', () => {
+    expect(actions.events('keywords')).toMatchSnapshot();
   });
 
   it('should create an action to notify of a failure fetching the calendar', () => {
@@ -26,6 +30,6 @@ describe('calendar actions', () => {
   });
 
   it('should create an action to notify of a success fetch for the calendar', () => {
-    expect(actions.success([{ pk: 1 }])).toMatchSnapshot();
+    expect(actions.success([{ pk: 1 }], 'keywords')).toMatchSnapshot();
   });
 });

--- a/__tests__/reducers/__snapshots__/calendar.spec.js.snap
+++ b/__tests__/reducers/__snapshots__/calendar.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`calendar reducer initially should not be fetched 1`] = `
 Object {
   "eventList": Array [],
+  "keywords": "",
   "loading": true,
   "status": "initial",
 }

--- a/__tests__/reducers/calendar.spec.js
+++ b/__tests__/reducers/calendar.spec.js
@@ -15,7 +15,7 @@ describe('calendar reducer', () => {
   describe('is refreshing', () => {
     const state = reducer(
       emptyState,
-      actions.refresh(),
+      actions.events(),
     );
 
     it('should be loading', () => {
@@ -26,7 +26,7 @@ describe('calendar reducer', () => {
   describe('is successful', () => {
     const state = reducer(
       emptyState,
-      actions.success([{ pk: 1 }]),
+      actions.success([{ pk: 1 }], 'keywords'),
     );
 
     it('should not be loading', () => {
@@ -35,6 +35,10 @@ describe('calendar reducer', () => {
 
     it('should have events', () => {
       expect(state).toHaveProperty('eventList', [{ pk: 1 }]);
+    });
+
+    it('should have keywords', () => {
+      expect(state).toHaveProperty('keywords', 'keywords');
     });
 
     it('should have status success', () => {

--- a/app/actions/calendar.js
+++ b/app/actions/calendar.js
@@ -1,5 +1,5 @@
 export const OPEN = 'CALENDAR_OPEN';
-export const REFRESH = 'CALENDAR_REFRESH';
+export const EVENTS = 'CALENDAR_EVENTS';
 export const SUCCESS = 'CALENDAR_SUCCESS';
 export const FAILURE = 'CALENDAR_FAILURE';
 export const FETCHING = 'CALENDAR_FETCHING';
@@ -10,16 +10,17 @@ export function open() {
   };
 }
 
-export function refresh() {
+export function events(keywords = '') {
   return {
-    type: REFRESH,
+    type: EVENTS,
+    payload: { keywords },
   };
 }
 
-export function success(eventList) {
+export function success(eventList, keywords) {
   return {
     type: SUCCESS,
-    payload: { eventList },
+    payload: { eventList, keywords },
   };
 }
 

--- a/app/reducers/calendar.js
+++ b/app/reducers/calendar.js
@@ -4,6 +4,7 @@ const initialState = {
   eventList: [],
   loading: true,
   status: 'initial',
+  keywords: '',
 };
 
 export default function calendar(state = initialState, action = {}) {
@@ -11,6 +12,7 @@ export default function calendar(state = initialState, action = {}) {
     case calendarActions.SUCCESS:
       return {
         eventList: action.payload.eventList,
+        keywords: action.payload.keywords,
         loading: false,
         status: 'success',
       };
@@ -20,7 +22,7 @@ export default function calendar(state = initialState, action = {}) {
         loading: false,
         status: 'failure',
       };
-    case calendarActions.REFRESH:
+    case calendarActions.EVENTS:
       return { ...state, loading: true };
     default:
       return { ...state };

--- a/app/sagas/calendar.js
+++ b/app/sagas/calendar.js
@@ -7,8 +7,10 @@ import * as calendarActions from '../actions/calendar';
 import { tokenSelector } from '../selectors/session';
 import reportError from '../utils/errorReporting';
 
-const calendar = function* calendar() {
+const calendar = function* calendar(action) {
+  const { keywords } = action.payload;
   const token = yield select(tokenSelector);
+
   const data = {
     method: 'GET',
     headers: {
@@ -20,11 +22,18 @@ const calendar = function* calendar() {
 
   yield put(calendarActions.fetching());
 
+  let params = null;
+  if (keywords) {
+    params = {
+      search: keywords,
+    };
+  }
+
   try {
-    const events = yield call(apiRequest, 'events', data);
+    const events = yield call(apiRequest, 'events', data, params);
     let partnerEvents = [];
     try {
-      partnerEvents = yield call(apiRequest, 'partners/events', data);
+      partnerEvents = yield call(apiRequest, 'partners/events', data, params);
       partnerEvents = partnerEvents.map((event) => ({
         ...event,
         pk: -event.pk,
@@ -33,7 +42,7 @@ const calendar = function* calendar() {
     } catch (error) {
       yield call(reportError, error);
     }
-    yield put(calendarActions.success(events.concat(partnerEvents)));
+    yield put(calendarActions.success(events.concat(partnerEvents), keywords));
   } catch (error) {
     yield call(reportError, error);
     yield put(calendarActions.failure());
@@ -41,5 +50,5 @@ const calendar = function* calendar() {
 };
 
 export default function* () {
-  yield takeEvery(calendarActions.REFRESH, calendar);
+  yield takeEvery(calendarActions.EVENTS, calendar);
 }

--- a/app/ui/screens/events/CalendarScreenConnector.js
+++ b/app/ui/screens/events/CalendarScreenConnector.js
@@ -6,10 +6,11 @@ const mapStateToProps = (state) => ({
   eventList: state.calendar.eventList,
   loading: state.calendar.loading,
   status: state.calendar.status,
+  keywords: state.calendar.keywords,
 });
 
 const mapDispatchToProps = {
-  refresh: calendarActions.refresh,
+  events: calendarActions.events,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(CalendarScreen);

--- a/app/ui/screens/events/style/CalendarScreen.js
+++ b/app/ui/screens/events/style/CalendarScreen.js
@@ -5,8 +5,9 @@ import Colors from '../../../style/Colors';
 import StyleSheet from '../../../style/StyleSheet';
 
 const styles = StyleSheet.create({
-  content: {
+  wrapper: {
     flex: 1,
+    flexDirection: 'column',
     backgroundColor: Colors.background,
   },
   day: {
@@ -48,6 +49,9 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 12,
     paddingLeft: 16,
+  },
+  keyboardView: {
+    flex: 1,
   },
 });
 


### PR DESCRIPTION
Closes #97 

Note: this PR depends on the same bugfix for the `SearchHeader` as #206: currently, if you search for an event, open it and then press the back button, the app first tries to close the (now hidden) search bar before it goes back one screen. In order to avoid conflicts, I've only included the fix in that PR.

### Summary
Introduces a search bar for the events calendar. Allows users to search for specific events, which can also be in the past.

### How to test
Steps to test the changes you made:
1. Go to the calendar screen
2. Search for an event
3. Notice that all events that match the search string are returned (normal events, partner events, events in the past, etc)
