### PR TITLE
Prevent profile page with error for non-members

### DIFF
--- a/__tests__/ui/components/memberView/MemberView.spec.js
+++ b/__tests__/ui/components/memberView/MemberView.spec.js
@@ -6,6 +6,10 @@ jest.mock('react-navigation', () => ({
   withNavigation: component => component,
 }));
 
+jest.mock('react-native-snackbar', () => ({
+  show: jest.fn(),
+}));
+
 describe('MemberView component', () => {
   const initialState = {
     session: {

--- a/app/ui/components/memberView/MemberView.js
+++ b/app/ui/components/memberView/MemberView.js
@@ -8,6 +8,7 @@ import {
   ViewPropTypes,
 } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
+import Snackbar from 'react-native-snackbar';
 
 import styles from './style/MemberView';
 import SquareView from './SquareView';
@@ -16,7 +17,13 @@ const MemberView = (props) => (
   <SquareView style={props.style} size={props.size}>
     <TouchableHighlight
       style={styles.image}
-      onPress={() => props.loadProfile(props.member.pk)}
+      onPress={() => {
+        if (props.member.pk) {
+          props.loadProfile(props.member.pk);
+        } else {
+          Snackbar.show({ text: `${props.member.name} is not a member of Thalia` });
+        }
+      }}
     >
       <ImageBackground style={styles.image} source={{ uri: props.member.photo }}>
         <LinearGradient colors={['#55000000', '#000000']} style={styles.overlayGradient} />
@@ -30,7 +37,7 @@ const MemberView = (props) => (
 
 MemberView.propTypes = {
   member: PropTypes.shape({
-    pk: PropTypes.number.isRequired,
+    pk: PropTypes.number,
     name: PropTypes.string.isRequired,
     photo: PropTypes.string.isRequired,
   }).isRequired,


### PR DESCRIPTION
### Summary
Prevents navigation to the profile page of someone who is not a member. For events, it is possible to register non-members through the backend. This PR ensures that clicking on such a person in the registration list does not result in an error page, but rather informs the user that this person is not a member.

### Previous behaviour
1. Go to the TAPC event (https://thalia.nu/events/672/)
2. Notice some of the registrations are for non-members
3. Press on one of these users
4. Be greeted with an error screen

### New behaviour
1. Go to the TAPC event
2. Notice some of the registrations are for non-members
3. Press on one of these users
4. See a snackbar with the message "$name is not a member of Thalia"
