### PR TITLE
Fix the registration fields clearing on save

### DIFF
--- a/app/reducers/registration.js
+++ b/app/reducers/registration.js
@@ -6,6 +6,20 @@ const initialState = {
   status: 'loading',
 };
 
+function updateFields(fields, values) {
+  /**
+   * Updates the registration fields with the newly entered values.
+   */
+  const newFields = {};
+  Object.keys(values).forEach((key) => {
+    newFields[key] = {
+      ...fields[key],
+      value: values[key],
+    };
+  });
+  return newFields;
+}
+
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case registrationActions.SHOW_FIELDS: {
@@ -13,6 +27,12 @@ export default function reducer(state = initialState, action = {}) {
         registration: action.payload.registration,
         fields: action.payload.fields,
         status: 'success',
+      };
+    }
+    case registrationActions.UPDATE: {
+      return {
+        ...state,
+        fields: updateFields(state.fields, action.payload.fields),
       };
     }
     case registrationActions.SUCCESS: {


### PR DESCRIPTION
### Summary
Registration fields are no longer reset for a brief moment when the user presses 'save'. Previously, when the form was submitted (and the app was waiting for a response), the form fields were reset to their old values. With this PR, they don't do that anymore. 

### How to test
Steps to test the changes you made:
1. Go to an event with registration fields
2. Update one or more fields
3. Press 'save'
4. Notice that the fields are not reset
