### PR TITLE
Fix strike-through text in events

### DIFF
--- a/app/ui/screens/events/EventScreen.js
+++ b/app/ui/screens/events/EventScreen.js
@@ -477,10 +477,25 @@ class EventScreen extends Component {
             <HTML
               html={data.description}
               onLinkPress={(event, href) => openUrl(href)}
+              alterNode={(node) => {
+                const newNode = node;
+                if (
+                  node.attribs &&
+                  node.attribs.style &&
+                  node.attribs.style.indexOf('text-decoration: line-through') >= 0
+                ) {
+                  newNode.attribs.style = node.attribs.style.replace(
+                    'text-decoration: line-through',
+                    'text-decoration-line: line-through'
+                  );
+                }
+                return newNode;
+              }}
               baseFontStyle={fontStyles}
               tagsStyles={{
                 a: linkStyles,
               }}
+              textSelectable
             />
             {this.registrationsGrid()}
           </ScrollView>


### PR DESCRIPTION
Closes #222

### Summary
Fix strike-through text in events.

### How to test
Steps to test the changes you made:
1. Set strike-through text in an event
2. Open said event
3. Strike-through text is visible!
